### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 *ErgoSNM* \- a split ergonomic keyboard that aims to make people leave their mouse behind.
 
-Features introduction, build guides and more information can be found in the [Docs:book:](https://siderakb.github.io/docs/ergosnm/)
+Features introduction, build guides and more information can be found in the [Docs:book:](https://siderakb.github.io/docs/intro)
 
 ## Footprint
 


### PR DESCRIPTION
The Docs link in the readme leads to a non-existent page. Should probably go to the intro page.